### PR TITLE
fixed setDraggableRegion() when dragging outside the window

### DIFF
--- a/src/api/window.ts
+++ b/src/api/window.ts
@@ -153,19 +153,23 @@ export function setDraggableRegion(domId: string): Promise<any> {
         if(!draggableRegion)
             reject(`Unable to find dom element: #${domId}`);
 
-        draggableRegion.addEventListener('mousedown', (evt: MouseEvent) => {
+        draggableRegion.addEventListener('pointerdown', (evt: PointerEvent) => {
             initialClientX = evt.clientX;
             initialClientY = evt.clientY;
-            draggableRegion.addEventListener('mousemove', onMouseMove);
+            draggableRegion.addEventListener('pointermove', onPointerMove);
+            draggableRegion.setPointerCapture(evt.pointerId);
         });
 
-        draggableRegion.addEventListener('mouseup', () => {
-            draggableRegion.removeEventListener('mousemove', onMouseMove);
+        draggableRegion.addEventListener('pointerup', (evt: PointerEvent) => {
+            draggableRegion.removeEventListener('pointermove', onPointerMove);
+            draggableRegion.releasePointerCapture(evt.pointerId);
         });
-        
-        async function onMouseMove(evt: MouseEvent) {
-            await Neutralino.window
-                .move(evt.screenX - initialClientX, evt.screenY - initialClientY);
+
+        async function onPointerMove(evt: PointerEvent) {
+            await Neutralino.window.move(
+                evt.screenX - initialClientX,
+                evt.screenY - initialClientY
+            );
         }
         
         resolve();


### PR DESCRIPTION
Used the SetPointerCapture event to keep getting PointerMove events even outside the browser window. Should fix: [https://github.com/neutralinojs/neutralinojs/issues/553](https://github.com/neutralinojs/neutralinojs/issues/553)

docs:
[https://developer.mozilla.org/en-US/docs/Web/API/Element/setPointerCapture](https://developer.mozilla.org/en-US/docs/Web/API/Element/setPointerCapture)