### PR TITLE
Update `Stats` Interface to support the new date related attributes.

### DIFF
--- a/src/api/filesystem.ts
+++ b/src/api/filesystem.ts
@@ -9,6 +9,8 @@ export interface Stats {
     size: number;
     isFile: boolean;
     isDirectory: boolean;
+    createdAt: number;
+    modifiedAt: number;
 }
 
 export function createDirectory(path: string): Promise<void> {


### PR DESCRIPTION
This commit extends the `Stats` interface of the `filesystem` API to include the two new attributes `createdAt` and `modifiedAt` introduced introduced [this Pull Request](https://github.com/neutralinojs/neutralinojs/pull/877).

