### PR TITLE
fix missing keyword in the dtsTemplate

### DIFF
--- a/build.mjs
+++ b/build.mjs
@@ -201,7 +201,7 @@ declare const NL_PID: number
 declare const NL_CCOMMIT: string;
 
 /** An array of custom methods */
-NL_CMETHODS: string[];
+declare const NL_CMETHODS: string[];
 
 ${
     // rollup-plugin-ts produce an empty map, maybe we will find a solution in the future.


### PR DESCRIPTION
Just a minor fix in the dts Template which is used in the build/dist/neutralino.d.ts