### PR TITLE
making NL_APPVERSION optional

### DIFF
--- a/src/globals.d.ts
+++ b/src/globals.d.ts
@@ -12,7 +12,7 @@ declare interface Window {
     /** Application identifier */
     NL_APPID: string;
     /** Application version */
-    NL_APPVERSION: string;
+    NL_APPVERSION?: string;
     /** Application path */
     NL_PATH: string;
     /** Returns true if extensions are enabled */


### PR DESCRIPTION
Resolves: #86 

This PR modifies to `global.d.ts` file to make the `NL_APPVERSION` property optional