### PR TITLE
changing datatype of constants from `string` to `enum`

### DIFF
--- a/src/enums.ts
+++ b/src/enums.ts
@@ -1,0 +1,22 @@
+export enum MODE {
+    Window,
+    Browser,
+    Cloud,
+    Chrome
+}
+
+export enum OS {
+    Linux,
+    Windows,
+    Darwin,
+    FreeBSD,
+    Unknown
+}
+
+export enum ARCH {
+    x64,
+    Arm,
+    Itanium,
+    ia32,
+    Unknown
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,10 @@
+import { MODE, OS, ARCH } from './enums';
+
 declare global {
 interface Window {
     // --- globals ---
     /** Mode of the application: window, browser, cloud, or chrome */
-    NL_MODE: string;
+    NL_MODE: MODE;
     /** Application port */
     NL_PORT: number;
     /** Command-line arguments */
@@ -20,9 +22,9 @@ interface Window {
     /** Returns true if extensions are enabled */
     NL_EXTENABLED: boolean;
     /** Operating system name: Linux, Windows, Darwin, FreeBSD, or Unknown */
-    NL_OS: string;
+    NL_OS: OS;
     /** CPU architecture: x64, arm, itanium, ia32, or unknown */
-    NL_ARCH: string;
+    NL_ARCH: ARCH;
     /** Neutralinojs server version */
     NL_VERSION: string;
     /** Current working directory */

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,7 +19,7 @@ interface Window {
     NL_PATH: string;
     /** Returns true if extensions are enabled */
     NL_EXTENABLED: boolean;
-    /** Operating system name: Linux, Windows, Darwin, FreeBSD, or Uknown */
+    /** Operating system name: Linux, Windows, Darwin, FreeBSD, or Unknown */
     NL_OS: string;
     /** CPU architecture: x64, arm, itanium, ia32, or unknown */
     NL_ARCH: string;


### PR DESCRIPTION
Resolves: #96 

This PR defines an `enum` for constants instead of `string` this enhances our `code readability` and provides better `type safety`.