### PR TITLE
Using enums for constants instead of string datatype

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,10 @@
+import * as NL_CONSTANTS from './types/enums';
+
 declare global {
 interface Window {
     // --- globals ---
     /** Mode of the application: window, browser, cloud, or chrome */
-    NL_MODE: string;
+    NL_MODE: NL_CONSTANTS.MODE;
     /** Application port */
     NL_PORT: number;
     /** Command-line arguments */
@@ -20,9 +22,9 @@ interface Window {
     /** Returns true if extensions are enabled */
     NL_EXTENABLED: boolean;
     /** Operating system name: Linux, Windows, Darwin, FreeBSD, or Uknown */
-    NL_OS: string;
+    NL_OS: NL_CONSTANTS.OS;
     /** CPU architecture: x64, arm, itanium, ia32, or unknown */
-    NL_ARCH: string;
+    NL_ARCH: NL_CONSTANTS.ARCH;
     /** Neutralinojs server version */
     NL_VERSION: string;
     /** Current working directory */

--- a/src/types/enums.ts
+++ b/src/types/enums.ts
@@ -1,0 +1,22 @@
+export enum MODE {
+    Window,
+    Browser,
+    Cloud,
+    Chrome
+}
+
+export enum OS {
+    Linux,
+    Windows,
+    Darwin,
+    FreeBSD,
+    Unknown
+}
+
+export enum ARCH {
+    x64,
+    Arm,
+    Itanium,
+    ia32,
+    Unknown
+}


### PR DESCRIPTION
Resolves: #96 

This PR adds `enums` for `constant values` instead of using `string datatype`.
This enhances our `code readability` and `type safety` 