### PR TITLE
Enhanced Error Reporting for Improved Debugging and User Experience

### DIFF
--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,0 +1,26 @@
+export class NeutralinoError extends Error {
+    code: string;
+    message: string;
+
+    constructor({
+        code,
+        message
+    }: {
+        code: string;
+        message: string;
+    }) {
+        super();
+        this.code = code;
+        this.message = message;
+    }
+}
+
+export function logError(e) {
+    const error = JSON.stringify(e);
+    const errorObj = JSON.parse(error);
+    if (errorObj && typeof errorObj === 'object' && 'code' in errorObj && 'message' in errorObj) {
+       throw new NeutralinoError({ code: errorObj.code, message: errorObj.message});
+    } else {
+        console.error('Invalid error object:', errorObj);
+    }
+}

--- a/src/ws/websocket.ts
+++ b/src/ws/websocket.ts
@@ -1,5 +1,6 @@
 import * as extensions from '../api/extensions';
 import * as events from '../browser/events';
+import { logError } from '../errors';
 import { base64ToBytesArray } from '../helpers';
 
 let ws;
@@ -15,27 +16,31 @@ export function init() {
     registerSocketEvents();
 }
 
-export function sendMessage(method: string, data?: any): Promise<any> {
-    return new Promise((resolve: any, reject: any) => {
+export async function sendMessage(method: string, data?: any): Promise<any> {
+    try {
+        return await new Promise((resolve: any, reject: any) => {
 
-        if(ws?.readyState != WebSocket.OPEN) {
-            sendWhenReady({method, data, resolve, reject});
-            return;
-        }
+            if(ws?.readyState != WebSocket.OPEN) {
+                sendWhenReady({method, data, resolve, reject});
+                return;
+            }
 
-        const id: string = uuidv4();
-        const accessToken: string = getAuthToken();
+            const id: string = uuidv4();
+            const accessToken: string = getAuthToken();
 
-        nativeCalls[id] = {resolve, reject};
+            nativeCalls[id] = {resolve, reject};
 
-        ws.send(JSON.stringify({
-            id,
-            method,
-            data,
-            accessToken
-        }));
+            ws.send(JSON.stringify({
+                id,
+                method,
+                data,
+                accessToken
+            }));
 
-    });
+        });
+    } catch (e) {
+        logError(e);
+    }
 }
 
 export function sendWhenReady(message: any) {


### PR DESCRIPTION
Resolves: #99

This PR adds a new `class` or throwing errors and gives more `descriptive errors`

This is what out errors look like now:
![error(1)](https://github.com/neutralinojs/neutralino.js/assets/119438857/4c57844d-83a1-4ca4-8227-24df08997312)

This is what they will look like after the changes introduced by this PR:
![error-now](https://github.com/neutralinojs/neutralino.js/assets/119438857/ab60a91e-b2d1-45e3-b4f1-881cdec2aa4a)
