### PR TITLE
api/computer: Add missing physical and virtual objects on MemoryInfo type def

### DIFF
--- a/src/api/computer.ts
+++ b/src/api/computer.ts
@@ -1,8 +1,14 @@
 import { sendMessage } from '../ws/websocket';
 
 export interface MemoryInfo {
-    total: number;
-    available: number;
+    physical: {
+        total: number;
+        available: number;
+    },
+    virtual: {
+        total: number;
+        available: number;
+    }
 }
 
 export interface KernelInfo {


### PR DESCRIPTION
The C++ API [returns an object](https://github.com/neutralinojs/neutralinojs/blob/0f3752aabb71deb5d3c8157839f0ef07bb9c4356/api/computer/computer.cpp#L62) containing two `physical` and `virtual` objects with the corresponding memory info.

[This is also defined by the docs](https://github.com/neutralinojs/neutralinojs.github.io/blob/bdfc876d9d7bcf21a323c315271948c031efa0de/docs/api/computer.md?plain=1#L7).

The data is returned as expected, and casting a fixed type manually does work with TS. This PR fixes the JS API's type.