### PR TITLE
:bug: Fix wrong enum values in enums.ts

### DIFF
--- a/src/types/enums.ts
+++ b/src/types/enums.ts
@@ -24,31 +24,31 @@ export enum MessageBoxChoice {
 
 //clipboard
 export enum ClipboardFormat {
-    unknown,
-    text,
-    image
+    unknown = 'unknown',
+    text = 'text',
+    image = 'image'
 }
 
 // NL_GLOBALS
 export enum Mode {
-    window,
-    browser,
-    cloud,
-    chrome
+    window = 'window',
+    browser = 'browser',
+    cloud = 'cloud',
+    chrome = 'chrome'
 }
 
 export enum OperatingSystem {
-    Linux,
-    Windows,
-    Darwin,
-    FreeBSD,
-    Unknown
+    Linux = 'Linux',
+    Windows = 'Windows',
+    Darwin = 'Darwin',
+    FreeBSD = 'FreeBSD',
+    Unknown = 'Unknown'
 }
 
 export enum Architecture {
-    x64,
-    arm,
-    itanium,
-    ia32,
-    unknown
+    x64 = 'x64',
+    arm = 'arm',
+    itanium = 'itanium',
+    ia32 = 'ia32',
+    unknown = 'unknown'
 }


### PR DESCRIPTION
Right now type definitions export several enums that don't have their values initialized, which leads them to have values `0`, `1`, `2`, and so on, when in fact they have string values. (As [per docs](https://neutralino.js.org/docs/api/global-variables) and factual values.) This leads to typescript errors.

![изображение](https://github.com/user-attachments/assets/d1aac28e-26df-475d-aea4-d923cc183c11)
![изображение](https://github.com/user-attachments/assets/4d0d4e5d-2ec8-4b55-a438-e4c4f010ca9b)

This PR corrects the `enums.ts` file so that each enum value has a corresponding correct string value.

![изображение](https://github.com/user-attachments/assets/0c1f728d-f4a6-41ad-963b-0da31f7c73b0)
