### PR TITLE
Fix issue #122:  windows.setTitle() issue Resolved

### DIFF
--- a/src/api/window.ts
+++ b/src/api/window.ts
@@ -11,7 +11,7 @@ const draggableRegions: WeakMap<HTMLElement, {
     pointerup: (e: PointerEvent) => void;
 }> = new WeakMap();
 
-export function setTitle(title: string): Promise<void> {
+export function setTitle(title: string = ''): Promise<void> {
     return sendMessage('window.setTitle', { title });
 };
 


### PR DESCRIPTION
The change adds a default parameter value of an empty string (= '' ") to the title parameter. 
This means: 
1. If setTitle() is called without parameters, title will default to an empty string
2. If setTitle("some title") is called with a parameter, it will use the provided value
3. The function will always send a valid string to the websocket message