### PR TITLE
instance check added to appendBinaryFile()

### DIFF
--- a/src/api/filesystem.ts
+++ b/src/api/filesystem.ts
@@ -35,6 +35,9 @@ export function writeBinaryFile(path: string, data: ArrayBuffer): Promise<void> 
 };
 
 export function appendBinaryFile(path: string, data: ArrayBuffer): Promise<void> {
+    if(!(data instanceof ArrayBuffer)){
+        throw new TypeError("Input data not of type ArrayBuffer")
+    }
     return sendMessage('filesystem.appendBinaryFile', {
         path,
         data: arrayBufferToBase64(data)


### PR DESCRIPTION
Added instance check to `appendBinaryFile()`  , if data not ArrayBuffer it will throw TypeError , Trying to solve issue #113 