### PR TITLE
:zap: Use 127.0.0.1 as the default websocket hostname instead of localhost

### DIFF
--- a/src/ws/websocket.ts
+++ b/src/ws/websocket.ts
@@ -11,7 +11,7 @@ export function init() {
     initAuth();
     const connectToken: string = getAuthToken().split('.')[1];
     const hostname: string = (window.NL_GINJECTED || window.NL_CINJECTED) ? 
-                            'localhost' : window.location.hostname;
+                            '127.0.0.1' : window.location.hostname;
     ws = new WebSocket(`ws://${hostname}:${window.NL_PORT}?connectToken=${connectToken}`);
     registerLibraryEvents();
     registerSocketEvents();


### PR DESCRIPTION
See https://github.com/neutralinojs/neutralinojs/pull/1358 for details.
This is a follow-up PR that makes Neutralino client library to connect to its server through 127.0.0.1 instead of localhost, which skips DNS resolution process and makes native APIs initialize faster on Windows.