### PR TITLE
add server.setVDocRoot api function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -129,3 +129,4 @@ tmp/
 temp/
 
 # End of https://www.toptal.com/developers/gitignore/api/node
+bun.lockb

--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -11,3 +11,7 @@ export function unmount(path: string): Promise<void> {
 export function getMounts(): Promise<void> {
     return sendMessage('server.getMounts');
 }
+
+export function setVDocRoot(path: string): Promise<void> {
+    return sendMessage('server.setVDocRoot', { path });
+}


### PR DESCRIPTION
## Description
Implements a virtual document root for local folders. When building an application to access local files, system functions can be used to read and display file content. However, if a file (such as an HTML document) references other local files (e.g., images in the same folder), these references typically fail to resolve (see #1291).

## Changes proposed
Adds a `setVDocRoot` function to designate a local folder as the virtual document root for resources.
```ts
export function setVDocRoot(path: string): Promise<void> {
    return sendMessage('server.setVDocRoot', { path });
}
```

## How to test it
Before opening a local HTML file containing referenced images, use `setVDocRoot` to set the virtual document root to the folder containing the HTML file and images. Verify that the images are displayed correctly.

## Deploy notes
This change introduces a new function, `setVDocRoot`, which may require adjustments to existing build processes or deployment scripts if they rely on specific file paths. Ensure that the correct path is passed to setVDocRoot during application initialization. Consider adding documentation or examples demonstrating its usage.

You need update your neutralino.js too

## Usage
```js
      Neutralino.server
         .setVDocRoot(path)
         .then((resault) => {
            console.log("setVDocRoot:", resault)
        })
        .catch((error) => {
          console.error("setVDocRoot error:", error);
        });
```