### PR TITLE
Added Api support for Env variables in os.spawnProcess

### DIFF
--- a/src/api/os.ts
+++ b/src/api/os.ts
@@ -9,15 +9,16 @@ import type {
     OpenDialogOptions,
     SaveDialogOptions,
     SpawnedProcess,
-    TrayOptions
+    TrayOptions,
+    SpawnedProcessOptions,
 } from '../types/api/os';
 
 export function execCommand(command: string, options?: ExecCommandOptions): Promise<ExecCommandResult> {
     return sendMessage('os.execCommand', { command, ...options });
 };
 
-export function spawnProcess(command: string, cwd?: string): Promise<SpawnedProcess> {
-    return sendMessage('os.spawnProcess', { command, cwd });
+export function spawnProcess(command: string, options?: SpawnedProcessOptions): Promise<SpawnedProcess> {
+    return sendMessage('os.spawnProcess', { command, ...options });
 };
 
 export function updateSpawnedProcess(id: number, event: string, data?: any): Promise<void> {

--- a/src/types/api/os.ts
+++ b/src/types/api/os.ts
@@ -16,6 +16,11 @@ export interface SpawnedProcess {
     pid: number;
 }
 
+export interface SpawnedProcessOptions {
+    cwd?: string;
+    envs?: Record<string, string>;
+}
+
 export interface Envs {
     [key: string]: string;
 }


### PR DESCRIPTION
**Related Issue:** [neutralinojs/neutralinojs#1373](https://github.com/neutralinojs/neutralinojs/issues/1373)

**Description:** 
This PR adds support for specifying environment variables using os.spawnProcess.

**Changes:**
- Added SpawnedProcessOptions interface.
- Updated spawnProcess function to accept these options correctly.


