### PR TITLE
Remove Duplicate window.NL_EXTENABLED Check

### DIFF
--- a/src/ws/websocket.ts
+++ b/src/ws/websocket.ts
@@ -53,12 +53,14 @@ export function sendWhenExtReady(extensionId: string, message: any) {
 }
 
 function registerLibraryEvents() {
+
+    if (!window.NL_EXTENABLED) {
+        return;
+    }
+
     events.on('ready', async () => {
         await processQueue(offlineMessageQueue);
 
-        if(!window.NL_EXTENABLED) {
-            return;
-        }
 
         let stats = await sendMessage('extensions.getStats');
         for(let extension of stats.connected) {
@@ -69,10 +71,6 @@ function registerLibraryEvents() {
     events.on('extClientConnect', (evt) => {
         events.dispatch('extensionReady', evt.detail);
     });
-
-    if(!window.NL_EXTENABLED) {
-        return;
-    }
 
     events.on('extensionReady', async (evt) => {
         if(evt.detail in extensionMessageQueue) {


### PR DESCRIPTION
## Summary
This PR removes a redundant check for window.NL_EXTENABLED in the registerLibraryEvents function, ensuring better efficiency and cleaner code.

## Changes Made

- Moved the `if (!window.NL_EXTENABLED) return;` check to the beginning of registerLibraryEvents.
- Removed the second occurrence of the same check.
- Ensured that event listeners are only registered when extensions are enabled.

## After Fix

```
function registerLibraryEvents() {
    if (!window.NL_EXTENABLED) {
        return;
    }

    events.on('ready', async () => {
        await processQueue(offlineMessageQueue);

        let stats = await sendMessage('extensions.getStats');
        for (let extension of stats.connected) {
            events.dispatch('extensionReady', extension);
        }
    });

    events.on('extClientConnect', (evt) => {
        events.dispatch('extensionReady', evt.detail);
    });

    events.on('extensionReady', async (evt) => {
        if (evt.detail in extensionMessageQueue) {
            await processQueue(extensionMessageQueue[evt.detail]);
            delete extensionMessageQueue[evt.detail];
        }
    });
}
```

## Impact

- No change in functionality.
- Minor performance improvement.
- Code is easier to read and maintain.