### PR TITLE
Add missing WindowMenu properties to types

### DIFF
--- a/src/types/api/window.ts
+++ b/src/types/api/window.ts
@@ -37,6 +37,8 @@ export interface WindowOptions extends WindowSizeOptions, WindowPosOptions {
   export interface WindowMenuItem {
       id?: string;
       text: string;
+      action?: string;
+      shortcut?: string;
       isDisabled?: boolean;
       isChecked?: boolean;
       menuItems?: WindowMenuItem[];


### PR DESCRIPTION
This PR adds the missing types for macOS predefined actions and shortcuts added in v6.1.0 https://github.com/neutralinojs/neutralinojs/releases/tag/v6.1.0