### PR TITLE
fix: cleanup window types and add center option

### DIFF
--- a/src/types/api/window.ts
+++ b/src/types/api/window.ts
@@ -15,9 +15,9 @@ export interface WindowOptions extends WindowSizeOptions, WindowPosOptions {
     injectClientLibrary?: boolean;
     injectScript?: string;
     processArgs?: string;
-  }
-  
-  export interface WindowSizeOptions {
+}
+
+export interface WindowSizeOptions {
     width?: number;
     height?: number;
     minWidth?: number;
@@ -25,21 +25,22 @@ export interface WindowOptions extends WindowSizeOptions, WindowPosOptions {
     maxWidth?: number;
     maxHeight?: number;
     resizable?: boolean;
-  }
-  
-  export interface WindowPosOptions {
-    x: number;
-    y: number;
-  }
+}
 
-  export interface WindowMenu extends Array<WindowMenuItem>{}
+export interface WindowPosOptions {
+    x?: number;
+    y?: number;
+    center?: boolean;
+}
 
-  export interface WindowMenuItem {
-      id?: string;
-      text: string;
-      action?: string;
-      shortcut?: string;
-      isDisabled?: boolean;
-      isChecked?: boolean;
-      menuItems?: WindowMenuItem[];
-  }
+export interface WindowMenu extends Array<WindowMenuItem> {}
+
+export interface WindowMenuItem {
+    id?: string;
+    text: string;
+    action?: string;
+    shortcut?: string;
+    isDisabled?: boolean;
+    isChecked?: boolean;
+    menuItems?: WindowMenuItem[];
+}


### PR DESCRIPTION
#162
Added the missing center property to WindowPosOptions and made x and y optional so centering works correctly in TypeScript. I also cleaned up the file to remove duplicate interface declarations and fix some broken formatting.

Changes:
Added center?: boolean to WindowPosOptions.
Made x and y optional in WindowPosOptions.
Removed duplicate/messy code in src/types/api/window.ts