### PR TITLE
 #157 refactor: replace enums with string literal types in enums.ts (#157)

### DIFF
--- a/src/types/enums.ts
+++ b/src/types/enums.ts
@@ -1,54 +1,33 @@
-// debug
-export enum LoggerType {
-    WARNING = 'WARNING',
-    ERROR = 'ERROR',
-    INFO = 'INFO'
-  }
 
-// os
-export enum Icon {
-    WARNING = 'WARNING',
-    ERROR = 'ERROR',
-    INFO = 'INFO',
-    QUESTION = 'QUESTION'
-}
+const LoggerTypes = ["WARNING", "ERROR", "INFO"] as const;
+export type LoggerType = typeof LoggerTypes[number];
 
-export enum MessageBoxChoice {
-    OK = 'OK',
-    OK_CANCEL = 'OK_CANCEL',
-    YES_NO = 'YES_NO',
-    YES_NO_CANCEL = 'YES_NO_CANCEL',
-    RETRY_CANCEL = 'RETRY_CANCEL',
-    ABORT_RETRY_IGNORE = 'ABORT_RETRY_IGNORE'
-}
 
-//clipboard
-export enum ClipboardFormat {
-    unknown = 'unknown',
-    text = 'text',
-    image = 'image'
-}
+const Icons = ["WARNING", "ERROR", "INFO", "QUESTION"] as const;
+export type Icon = typeof Icons[number];
 
-// NL_GLOBALS
-export enum Mode {
-    window = 'window',
-    browser = 'browser',
-    cloud = 'cloud',
-    chrome = 'chrome'
-}
+const MessageBoxChoices = [
+    "OK",
+    "OK_CANCEL",
+    "YES_NO",
+    "YES_NO_CANCEL",
+    "RETRY_CANCEL",
+    "ABORT_RETRY_IGNORE"
+] as const;
+export type MessageBoxChoice = typeof MessageBoxChoices[number];
 
-export enum OperatingSystem {
-    Linux = 'Linux',
-    Windows = 'Windows',
-    Darwin = 'Darwin',
-    FreeBSD = 'FreeBSD',
-    Unknown = 'Unknown'
-}
 
-export enum Architecture {
-    x64 = 'x64',
-    arm = 'arm',
-    itanium = 'itanium',
-    ia32 = 'ia32',
-    unknown = 'unknown'
-}
+const ClipboardFormats = ["unknown", "text", "image"] as const;
+export type ClipboardFormat = typeof ClipboardFormats[number];
+
+
+const Modes = ["window", "browser", "cloud", "chrome"] as const;
+export type Mode = typeof Modes[number];
+
+
+const OperatingSystems = ["Linux", "Windows", "Darwin", "FreeBSD", "Unknown"] as const;
+export type OperatingSystem = typeof OperatingSystems[number];
+
+
+const Architectures = ["x64", "arm", "itanium", "ia32", "unknown"] as const;
+export type Architecture = typeof Architectures[number];


### PR DESCRIPTION
I have refactored the enums.ts file to use the const array and type union pattern as requested in #157.
 This improves developer experience by allowing better autocomplete and removing the need for enum imports.

I have verified the changes by running npm run build, which passed successfully.