### PR TITLE
# 145  Improve updater error when install() is called before checkForUpdates()

### DIFF
--- a/src/api/updater.ts
+++ b/src/api/updater.ts
@@ -49,7 +49,7 @@ export function install(): Promise<void> {
         if(!manifest) {
             return reject({
                 code: 'NE_UP_UPDNOUF',
-                message: 'No update manifest loaded. Make sure that updater.checkForUpdates() has been called before install().'
+                message: 'No update manifest loaded. Make sure that updater.checkForUpdates() is called before install().'
             });
         }
 


### PR DESCRIPTION
Calling Neutralino.updater.install() before checkForUpdates() previously resulted in a generic and confusing error.

This PR adds a clear lifecycle check so the updater throws a descriptive error when install() is called without a loaded manifest, making the API behavior explicit and easier to understand.

Fixes #145