### PR TITLE
 #173 feat: add updateTrayMenuItem helper to os api

### DIFF
--- a/src/api/os.ts
+++ b/src/api/os.ts
@@ -61,6 +61,20 @@ export function showMessageBox(title: string, content: string,
 export function setTray(options: TrayOptions): Promise<void> {
     return sendMessage('os.setTray', options);
 };
+export function updateTrayMenuItem( menuItem: Partial<TrayOptions['menuItems'][number]> & { id: string }, tray: TrayOptions): Promise<void> {
+    if (!tray || !tray.menuItems) {
+        return Promise.reject(new Error('Neutralino.os.updateTrayMenuItem: Invalid tray object.'));
+    }
+
+    const index = tray.menuItems.findIndex((item) => item.id === menuItem.id);
+
+    if (index !== -1) {
+        tray.menuItems[index] = { ...tray.menuItems[index], ...menuItem };
+        return setTray(tray);
+    } else {
+        return Promise.reject(new Error(`Neutralino.os.updateTrayMenuItem: Item with id "${menuItem.id}" not found.`));
+    }
+};
 
 export function open(url: string): Promise<void> {
     return sendMessage('os.open', { url });


### PR DESCRIPTION
#173 
Added a helper updateTrayMenuItem

Right now, toggling a checkbox in the tray is a pain because you have to manually update the tray object and call setTray every time. This helper does that work for you—just pass the item id and the fields you want to change, and it handles the rest.

Changes:
Finds the menu item by ID and merges the new properties.
Automatically calls setTray to refresh the UI.
Uses Partial types for better autocomplete.
