### PR TITLE
code correction

### DIFF
--- a/src/ws/websocket.ts
+++ b/src/ws/websocket.ts
@@ -8,6 +8,7 @@ const extensionMessageQueue = {}
 
 export function init() {
     initAuth();
+
     const connectToken: string = getAuthToken().split('.')[1];
     const hostname: string = (window.NL_GINJECTED || window.NL_CINJECTED) ? 
                             '127.0.0.1' : window.location.hostname;
@@ -141,18 +142,32 @@ async function processQueue(messageQueue: any[]) {
     }
 }
 
+function renderFatalError(code: string, message: string) {
+    try {
+        ws?.close();
+    } catch {}
+
+    document.body.replaceChildren();
+    const container = document.createElement('div');
+    container.innerHTML = `<code>${code}</code>: ${message}`;
+
+    document.body.appendChild(container);
+}
+
 function handleNativeMethodTokenError() {
-    ws.close();
-    document.body.innerText = '';
-    document.write('<code>NE_RT_INVTOKN</code>: Neutralinojs application cannot' +
-                                    ' execute native methods since <code>NL_TOKEN</code> is invalid.');
+    renderFatalError(
+        'NE_RT_INVTOKN',
+        'Neutralinojs application cannot execute native methods since <code>NL_TOKEN</code> is invalid.'
+    );
 }
 
 function handleConnectError() {
-    document.body.innerText = '';
-    document.write('<code>NE_CL_IVCTOKN</code>: Neutralinojs application cannot' +
-                                    ' connect with the framework core using <code>NL_TOKEN</code>.');
+    renderFatalError(
+        'NE_CL_IVCTOKN',
+        'Neutralinojs application cannot connect with the framework core using <code>NL_TOKEN</code>.'
+    );
 }
+
 
 function initAuth() {
     if (window.NL_TOKEN) {

--- a/src/ws/websocket.ts
+++ b/src/ws/websocket.ts
@@ -8,7 +8,6 @@ const extensionMessageQueue = {}
 
 export function init() {
     initAuth();
-
     const connectToken: string = getAuthToken().split('.')[1];
     const hostname: string = (window.NL_GINJECTED || window.NL_CINJECTED) ? 
                             '127.0.0.1' : window.location.hostname;

--- a/src/ws/websocket.ts
+++ b/src/ws/websocket.ts
@@ -167,7 +167,6 @@ function handleConnectError() {
     );
 }
 
-
 function initAuth() {
     if (window.NL_TOKEN) {
         sessionStorage.setItem('NL_TOKEN', window.NL_TOKEN);

--- a/src/ws/websocket.ts
+++ b/src/ws/websocket.ts
@@ -142,18 +142,14 @@ async function processQueue(messageQueue: any[]) {
 }
 
 function renderFatalError(code: string, message: string) {
-    try {
-        ws?.close();
-    } catch {}
-
     document.body.replaceChildren();
     const container = document.createElement('div');
     container.innerHTML = `<code>${code}</code>: ${message}`;
-
     document.body.appendChild(container);
 }
 
 function handleNativeMethodTokenError() {
+    ws.close();
     renderFatalError(
         'NE_RT_INVTOKN',
         'Neutralinojs application cannot execute native methods since <code>NL_TOKEN</code> is invalid.'


### PR DESCRIPTION
Replaced deprecated document.write() in websocket error handlers with safe DOM rendering, preserving identical output while improving compatibility and preventing browser warnings or silent failures.
#186 