### PR TITLE
Add useTemplateIcon option to TrayOptions

### DIFF
--- a/src/types/api/os.ts
+++ b/src/types/api/os.ts
@@ -49,6 +49,7 @@ export interface Filter {
 export interface TrayOptions {
     icon: string;
     menuItems: TrayMenuItem[];
+    useTemplateIcon?: boolean;
 }
 
 export interface TrayMenuItem {


### PR DESCRIPTION
## Description

This pull request adds TypeScript type definition for the `useTemplateIcon` option in `TrayOptions`. This option enables macOS template icons that automatically adapt their color based on the menu bar background (light/dark mode).

Companion PR for neutralinojs/neutralinojs#1550, which implements the native side. Addresses issue neutralinojs/neutralinojs#991.

## Changes proposed

- Add `useTemplateIcon?: boolean` to `TrayOptions` interface

## Deploy notes

This PR should be merged and released together with neutralinojs/neutralinojs#1550, which implements the native side of this feature.
