### PR TITLE
Fix token loss when tokenSecurity is set to one-time

### DIFF
--- a/src/ws/websocket.ts
+++ b/src/ws/websocket.ts
@@ -158,6 +158,9 @@ function initAuth() {
     if (window.NL_TOKEN) {
         sessionStorage.setItem('NL_TOKEN', window.NL_TOKEN);
     }
+    else if (sessionStorage.getItem('NL_TOKEN')) {
+        window.NL_TOKEN = sessionStorage.getItem('NL_TOKEN');
+    }
 }
 function getAuthToken() {
     return window.NL_TOKEN || sessionStorage.getItem('NL_TOKEN') || '';


### PR DESCRIPTION
## Summary
- Fixes the app becoming unresponsive (unable to close via `Neutralino.app.exit()`) after page reload or second window creation when `tokenSecurity` is set to `"one-time"`
- Restores `NL_TOKEN` from `sessionStorage` when the server returns an empty token on subsequent `getGlobalVars()` calls

## Root Cause
With `tokenSecurity: "one-time"`, the server-side `getToken()` returns the real token only on the first call, then returns `""` for all subsequent calls. On page reloads or second window creation, `window.NL_TOKEN` gets overwritten with an empty string, and since `initAuth()` only stores non-empty tokens, the valid token is lost.

## Fix
Added an `else if` branch in `initAuth()` to restore the token from `sessionStorage` back to `window.NL_TOKEN` when the server sends an empty token but a valid one was previously stored.

## Test plan
- [ ] Build the client library (`npm run build`)
- [ ] Test with `tokenSecurity: "one-time"` — verify `app.exit()` works after page reload
- [ ] Test with `tokenSecurity: "none"` — verify no regression
- [ ] Test in window, browser, and cloud modes

Fixes #188