### PR TITLE
fix: correct outdated script path in Developer FAQ

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,8 @@ How to test with the Neutralinojs server?
 
 ```bash
 cd ../neutralinojs
-bash ./bin/script_update_client.sh
+bash ./scripts/update_client.sh
+# This script builds neutralino.js and copies it to bin/resources/js
 ./bin/neutralino-{platform}_{arch} --load-dir-res # Eg: ./bin/neutralino-linux_x64 --load-dir-res
 ```
 


### PR DESCRIPTION
Fixes #182

## Problem
The Developer FAQ in README.md referenced a wrong script path:
`bash ./bin/script_update_client.sh`
This script does not exist, causing confusion for contributors.

## Fix
Updated the path to the correct location:
`bash ./scripts/update_client.sh`
Also added a comment explaining what the script does.