### PR TITLE
Fix/computer sendkey type and changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ rename `Unreleased` topic with the new version tag. Finally, create a new `Unrel
 
 ## Unreleased
 
+### API: computer
+- Export `computer.setMousePosition(x, y)` to update mouse cursor position.
+- Export `computer.setMouseGrabbing(grabbing: boolean)` to confine mouse within app window.
+- Export `computer.sendKey(keyCode, keyState?)` to simulate keyboard events. Accepted `keyState` values: `press`, `down`, and `up`.
+
 ## v6.5.0
 
 ### API: window

--- a/README.md
+++ b/README.md
@@ -31,8 +31,7 @@ How to test with the Neutralinojs server?
 
 ```bash
 cd ../neutralinojs
-bash ./scripts/update_client.sh
-# This script builds neutralino.js and copies it to bin/resources/js
+bash ./bin/script_update_client.sh
 ./bin/neutralino-{platform}_{arch} --load-dir-res # Eg: ./bin/neutralino-linux_x64 --load-dir-res
 ```
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,8 @@ How to test with the Neutralinojs server?
 
 ```bash
 cd ../neutralinojs
-bash ./bin/script_update_client.sh
+bash ./scripts/update_client.sh
+# This script builds neutralino.js and copies it to bin/resources/js
 ./bin/neutralino-{platform}_{arch} --load-dir-res # Eg: ./bin/neutralino-linux_x64 --load-dir-res
 ```
 

--- a/src/api/computer.ts
+++ b/src/api/computer.ts
@@ -44,6 +44,6 @@ export function setMouseGrabbing(grabbing: boolean): Promise<void> {
     return sendMessage('computer.setMouseGrabbing', { grabbing });
 }
 
-export function sendKey(keyCode: number, up: boolean): Promise<void> {
-    return sendMessage('computer.sendKey', { keyCode, up });
+export function sendKey(keyCode: number, keyState?: 'press' | 'down' | 'up'): Promise<void> {
+    return sendMessage('computer.sendKey', { keyCode, keyState });
 }


### PR DESCRIPTION
Fixes #222

## Problem
`computer.sendKey()` had incorrect parameter type:
- Named `up: boolean` instead of `keyState?: 'press' | 'down' | 'up'`
- Passed `{ keyCode, up }` to server instead of `{ keyCode, keyState }`

According to the framework CHANGELOG, keyState accepts string  values 'press', 'down', 'up' — not a boolean.

## Changes
- Corrected parameter name and type for `sendKey()` in `src/api/computer.ts`
- Added missing Unreleased changelog entries for `setMousePosition`,  `setMouseGrabbing`, and `sendKey` in `CHANGELOG.md`