### PR TITLE
fix: correctly parse os dialog options and provide fallback titles

### DIFF
--- a/src/api/os.ts
+++ b/src/api/os.ts
@@ -38,15 +38,36 @@ export function getEnvs(): Promise<Envs> {
 };
 
 export function showOpenDialog(title?: string, options?: OpenDialogOptions): Promise<string[]> {
-    return sendMessage('os.showOpenDialog', { title, ...options });
+    if (typeof title === 'object') {
+        options = title as unknown as OpenDialogOptions;
+        title = undefined;
+    }
+    return sendMessage('os.showOpenDialog', {
+        title: title ?? 'Open a file',
+        ...options,
+    });
 };
 
 export function showFolderDialog(title?: string, options?: FolderDialogOptions): Promise<string> {
-    return sendMessage('os.showFolderDialog', { title, ...options });
+    if (typeof title === 'object') {
+        options = title as unknown as FolderDialogOptions;
+        title = undefined;
+    }
+    return sendMessage('os.showFolderDialog', {
+        title: title ?? 'Select a folder',
+        ...options,
+    });
 };
 
 export function showSaveDialog(title?: string, options?: SaveDialogOptions): Promise<string> {
-    return sendMessage('os.showSaveDialog', { title, ...options });
+    if (typeof title === 'object') {
+        options = title as unknown as SaveDialogOptions;
+        title = undefined;
+    }
+    return sendMessage('os.showSaveDialog', {
+        title: title ?? 'Save a file',
+        ...options,
+    });
 };
 
 export function showNotification(title: string, content: string, icon?: Icon): Promise<void> {
@@ -54,7 +75,7 @@ export function showNotification(title: string, content: string, icon?: Icon): P
 };
 
 export function showMessageBox(title: string, content: string,
-                choice?: MessageBoxChoice, icon?: Icon): Promise<string> {
+    choice?: MessageBoxChoice, icon?: Icon): Promise<string> {
     return sendMessage('os.showMessageBox', { title, content, choice, icon });
 };
 


### PR DESCRIPTION
### Description

This PR fixes a bug in the `os` dialog APIs (`showOpenDialog`, `showFolderDialog`, and `showSaveDialog`) where calling the methods without a `title` argument (e.g. passing only an `options` object) would fail with a `NE_RT_NATRTER` error (`"Native method execution error occurred. Required parameter is missing:"`).

### What was the issue?

There were two linked issues causing this bug:

1. **Client-side argument parsing:** The library incorrectly assumed the first argument was always the `title` string. If an `options` object was passed as the first argument, it was incorrectly assigned to the `title` parameter, leaving `options` undefined and sending an invalid payload structure to the native binary.
2. **Native C++ server crash:** When the native server's C++ router received the `filters` array without a corresponding `title` field, it threw a C++ runtime exception (`NE_RT_NATRTER`). The router caught this exception, but it surfaced as a generic, misleading error message.

### How this PR fixes it:

1. **Corrected parameter type-checking:** The functions now check if `typeof title === 'object'`. If so, the object is correctly assigned to `options` and the `title` is set to `undefined`.
2. **Fallback default titles:** To prevent the native C++ binary from crashing when a title is omitted by the user, the client library now gracefully falls back to injecting the same default titles the server expects (`'Open a file'`, `'Select a folder'`, and `'Save a file'`). 

By ensuring a valid string is always sent as the title, we bypass the server crash and allow developers to use the dialog APIs seamlessly with only an options object (e.g., `os.showOpenDialog({ filters: [...] })`).

### Testing

Verified locally with a React app running `neu run`.

- `os.showOpenDialog("Custom Title", { filters: [...] })` ✅ (Works as expected)
- `os.showOpenDialog({ filters: [...] })` ✅ (Now works and uses the default "Open a file" title)
- `os.showOpenDialog()` ✅ (Works as expected)
