### PR TITLE
fix: optional sendKey state and export SendKeyState enum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,13 +6,17 @@ rename `Unreleased` topic with the new version tag. Finally, create a new `Unrel
 
 ## Unreleased
 
+### TypeScript
+- Make `computer.sendKey` `state` parameter optional (server defaults to `press`).
+- Export `SendKeyState` enum for npm consumers.
+
 ## v6.7.0
 
 ### API: os
 - Add `useTemplateIcon: boolean` option to `os.setTray(options)`.
 
 ### API: computer
-- Export `computer.setMousePosition(x,y)`, `computer.sendKey(keycode, keyState)`, and `computer.setMouseGrabbling(grabbing: boolean)` functions.
+- Export `computer.setMousePosition(x,y)`, `computer.sendKey(key, state)`, and `computer.setMouseGrabbing(grabbing: boolean)` functions.
 
 ## v6.5.0
 

--- a/src/api/computer.ts
+++ b/src/api/computer.ts
@@ -49,6 +49,9 @@ export function setMouseGrabbing(grabbing: boolean): Promise<void> {
     return sendMessage('computer.setMouseGrabbing', { grabbing });
 }
 
-export function sendKey(key: number, state: SendKeyState): Promise<void> {
-    return sendMessage('computer.sendKey', { key, state });
+export function sendKey(key: number, state?: SendKeyState): Promise<void> {
+    if (state !== undefined) {
+        return sendMessage('computer.sendKey', { key, state });
+    }
+    return sendMessage('computer.sendKey', { key });
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -65,6 +65,7 @@ export * as server from './api/server';
 export * as custom from './api/custom';
 
 export { init } from './api/init';
+export { SendKeyState } from './types/enums';
 
 export type * from './types/api/protocol';
 export type * from './types/api/app';


### PR DESCRIPTION
## Summary
- Makes `computer.sendKey(key, state?)` optional second argument (server defaults to `press`)
- Omits `state` from the WebSocket payload when not provided
- Exports `SendKeyState` enum from the package entry point
- Documents changes in CHANGELOG; fixes typo in v6.7.0 computer API line

## Related
- Follow-up to #222 (core fix already landed in #241 / #243)

## Test plan
- [x] `npm run build` passes
- [ ] `Neutralino.computer.sendKey(38)` works without second arg (manual test with Neutralino app)
- [ ] `Neutralino.computer.sendKey(38, 'down')` still works