### PR TITLE
Api support for net.*

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ rename `Unreleased` topic with the new version tag. Finally, create a new `Unrel
 
 ## Unreleased
 
+### API: net
+- Export `net.reqeust(url, method, options)`
+- Export `net.get(url, options)`, `net.post(url, options)`, `net.put(url, options)`, `net.del(url, options)`, `net.patch(url, options)`, `net.head(url, options)`, and `net.options(url, options)`
+
 ## v6.8.0
 
 ### API: os

--- a/package-lock.json
+++ b/package-lock.json
@@ -863,6 +863,7 @@
             "integrity": "sha512-klQbnPAAiGYFyI02+znpBRLyjL4/BrBd0nyWkdC0s/6xFLkXYQ8OoRrSkqacS1ddVxf/LDyODIKbQ5TgKAf/Fg==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@typescript-eslint/scope-manager": "8.56.1",
                 "@typescript-eslint/types": "8.56.1",
@@ -1067,6 +1068,7 @@
             "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "bin": {
                 "acorn": "bin/acorn"
             },
@@ -1333,6 +1335,7 @@
             "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.8.0",
                 "@eslint-community/regexpp": "^4.12.1",
@@ -2196,6 +2199,7 @@
             "integrity": "sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@types/estree": "1.0.8"
             },
@@ -2518,7 +2522,8 @@
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
             "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
             "dev": true,
-            "license": "0BSD"
+            "license": "0BSD",
+            "peer": true
         },
         "node_modules/type-check": {
             "version": "0.4.0",
@@ -2539,6 +2544,7 @@
             "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
             "dev": true,
             "license": "Apache-2.0",
+            "peer": true,
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"

--- a/src/api/net.ts
+++ b/src/api/net.ts
@@ -1,0 +1,35 @@
+import { sendMessage } from '../ws/websocket';
+import type { NetRequestOptions, NetResponse } from "../types/api/net";
+
+export function request(url: string, method?: string, options?: NetRequestOptions): Promise<NetResponse> {
+    method = (method || "GET").toUpperCase();
+    return sendMessage('net.request', { url, method, ...options });
+};
+
+export function get(url: string, options?: NetRequestOptions): Promise<NetResponse> {
+    return request(url, "GET", options);
+};
+
+export function post(url: string, options?: NetRequestOptions): Promise<NetResponse> {
+    return request(url, "POST", options);
+};
+
+export function head(url: string, options?: NetRequestOptions): Promise<NetResponse> {
+    return request(url, "HEAD", options);
+};
+
+export function put(url: string, options?: NetRequestOptions): Promise<NetResponse> {
+    return request(url, "PUT", options);
+};
+
+export function del(url: string, options?: NetRequestOptions): Promise<NetResponse> {
+    return request(url, "DELETE", options);
+};
+
+export function patch(url: string, options?: NetRequestOptions): Promise<NetResponse> {
+    return request(url, "PATCH", options);
+};
+
+export function options(url: string, options?: NetRequestOptions): Promise<NetResponse> {
+    return request(url, "OPTIONS", options);
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -62,6 +62,7 @@ export * as updater from './api/updater';
 export * as clipboard from './api/clipboard';
 export * as resources from './api/resources';
 export * as server from './api/server';
+export * as net from './api/net';
 export * as custom from './api/custom';
 
 export { init } from './api/init';
@@ -76,5 +77,6 @@ export type * from './types/api/init';
 export type * from './types/api/os';
 export type * from './types/api/updater';
 export type * from './types/api/window';
+export type * from './types/api/net';
 export type * from './types/enums';
 export type * from './types/events';

--- a/src/types/api/net.ts
+++ b/src/types/api/net.ts
@@ -19,7 +19,7 @@ export interface NetRequestOptions {
 }
 
 export interface NetResponse {
-    statusCode: number,
+    status: number,
     text: string,
     reason: string,
     headers: NetHeaders[],

--- a/src/types/api/net.ts
+++ b/src/types/api/net.ts
@@ -1,0 +1,28 @@
+export interface NetHeaders {
+    [key: string]: string;
+}
+
+export interface NetParams {
+    [key: string]: string;
+}
+
+export interface NetRequestOptions {
+    timeout?: boolean,
+    params?: NetParams[],
+    headers?: NetHeaders[],
+    auth?: {
+        username: string,
+        password: string
+    },
+    encodePath: boolean,
+    keepAlive: boolean
+}
+
+export interface NetResponse {
+    statusCode: number,
+    text: string,
+    reason: string,
+    headers: NetHeaders[],
+    cookies: string,
+    version: string
+}


### PR DESCRIPTION
# Api support for net.*

## Summary
Added `net.request(url, method, options)`, `net.get(url, options)`, `net.post(url, options)`, `net.head(url, options)`, `net.put(url, options)`, `net.patch(url, options)`, `net.del(url, options)`, `net.options(url, options)`

## Changes
| File                                    | Change                                                                        |
| ---------------------------- | --------------------------------------------------------- |
| `src/types/api/net.ts`        | `NetRequestOptions`, `NetResponse`                          |
| `src/api/net.ts`                | `request(url, method, options)`, `get(url, options)`, `post(url, options)`, `head(url, options)`, `put(url, options)`, `patch(url, options)`, `del(url, options)`, `options(url, options)`                          |

## Usage
```
let res = await Neutralino.net.get("https://example.com/", {
    headers: {
        "User-Agent": ""
    },
    timeout: 3000
});

res.text;
res.statusCode;
res.reason;
res.cookies;
res.headers;
res.version;
```

## Notes
Streaming support is currently unavailable.
The tests have passed on both Windows and Ubuntu.

For more details, please check the related PR: [neutralinojs/pull/1793](https://github.com/neutralinojs/neutralinojs/pull/1793).