### PR TITLE
fix Neutralino.net.delete reserved keyword issue

### DIFF
--- a/src/api/net.ts
+++ b/src/api/net.ts
@@ -1,36 +1,46 @@
 import { sendMessage } from '../ws/websocket';
 import type { NetRequestOptions, NetResponse } from "../types/api/net";
 
-export function request(url: string, method?: string, options?: NetRequestOptions): Promise<NetResponse> {
+function request(url: string, method?: string, options?: NetRequestOptions): Promise<NetResponse> {
     method = (method || "GET").toUpperCase();
     return sendMessage('net.request', { url, method, ...options });
 };
 
-export function get(url: string, options?: NetRequestOptions): Promise<NetResponse> {
+function get(url: string, options?: NetRequestOptions): Promise<NetResponse> {
     return request(url, "GET", options);
 };
 
-export function post(url: string, options?: NetRequestOptions): Promise<NetResponse> {
+function post(url: string, options?: NetRequestOptions): Promise<NetResponse> {
     return request(url, "POST", options);
 };
 
-export function head(url: string, options?: NetRequestOptions): Promise<NetResponse> {
+function head(url: string, options?: NetRequestOptions): Promise<NetResponse> {
     return request(url, "HEAD", options);
 };
 
-export function put(url: string, options?: NetRequestOptions): Promise<NetResponse> {
+function put(url: string, options?: NetRequestOptions): Promise<NetResponse> {
     return request(url, "PUT", options);
 };
 
 function __delete(url: string, options?: NetRequestOptions): Promise<NetResponse> {
     return request(url, "DELETE", options);
 };
-export { __delete as delete } // 'delete' is a keyword, so direct export won't work
 
-export function patch(url: string, options?: NetRequestOptions): Promise<NetResponse> {
+function patch(url: string, options?: NetRequestOptions): Promise<NetResponse> {
     return request(url, "PATCH", options);
 };
 
-export function options(url: string, options?: NetRequestOptions): Promise<NetResponse> {
+function options(url: string, options?: NetRequestOptions): Promise<NetResponse> {
     return request(url, "OPTIONS", options);
+};
+
+export const net = {
+    request,
+    get,
+    post,
+    head,
+    put,
+    patch,
+    options,
+    delete: __delete,
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -62,7 +62,7 @@ export * as updater from './api/updater';
 export * as clipboard from './api/clipboard';
 export * as resources from './api/resources';
 export * as server from './api/server';
-export * as net from './api/net';
+export { net } from './api/net';
 export * as custom from './api/custom';
 
 export { init } from './api/init';


### PR DESCRIPTION
`delete` is a reserved keyword in javascript.

The previous implementation attempted to get around this using `export { __delete as delete }`, however this still resulted in a final `.d.ts` file causing issues in major IDEs including Webstorm.  This could result in the file failing to be parsed, making typescript being unavailable to an end-user without manually editing the file.

This alternative approach protects us from this outcome by generating an output form of:

```ts
export declare const net: {
	request: typeof request;
	get: typeof get;
	post: typeof post;
	head: typeof head;
	put: typeof put;
	patch: typeof patch;
	options: typeof options;
	delete: typeof __delete;
};
```

this does result in slightly different syntax highlighting in some IDEs, but it parses properly because it uses `delete` as a property key, which is allowed.

I would personally strongly recommend renaming this method, as using a reserved javascript keyword for a method name is bad practice, but that is outside of the scope of this PR.