### PR TITLE
WIP: Add documentation to typescript definitions

### DIFF
--- a/build.mjs
+++ b/build.mjs
@@ -24,6 +24,7 @@ import Json from '@rollup/plugin-json';
 import Minify from '@rollup/plugin-terser';
 import cleanup from 'rollup-plugin-cleanup';
 import { generateDtsBundle } from 'dts-bundle-generator';
+import { patchWithDocs } from './patchWithDocs.js';
 
 // JSON modules is experimental https://nodejs.org/api/esm.html#esm_experimental_json_modules
 const { version } = JSON.parse(
@@ -87,6 +88,9 @@ rollup({
             esModule: false,
         });
         return 0;
+    })
+    .then(() => {
+        return patchWithDocs();
     })
     .then(returned => {
         console.log('Rolling up typescript declarations');

--- a/loadDocs.js
+++ b/loadDocs.js
@@ -1,0 +1,193 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { marked } from 'marked';
+
+const DOCS_REPO_PATH = path.resolve(
+    path.dirname(fileURLToPath(import.meta.url)),
+    '../neutralinojs.github.io',
+);
+const apiDocsPath = path.join(DOCS_REPO_PATH, 'docs', 'api');
+
+const DOCS_REPO_URL =
+    'https://github.com/neutralinojs/neutralinojs.github.io.git';
+const DOCS_NOT_FOUND_MESSAGE =
+    `Neutralino documentation not found at ${DOCS_REPO_PATH}\n` +
+    `Run \`git clone ${DOCS_REPO_URL}\` to clone it.`;
+
+async function assertDocsRepositoryExists() {
+    return new Promise((resolve, reject) => {
+        fs.stat(apiDocsPath, (err, stats) => {
+            if (err || !stats.isDirectory())
+                return reject(DOCS_NOT_FOUND_MESSAGE);
+            resolve();
+        });
+    });
+}
+
+async function getMarkdownFiles(directoryPath) {
+    const entries = fs.readdirSync(directoryPath, { withFileTypes: true });
+    return entries
+        .filter(entry => entry.isFile())
+        .filter(entry => entry.name.endsWith('.md'))
+        .map(entry => path.join(directoryPath, entry.name));
+}
+
+function parseMethodHeading(heading) {
+    const match = heading.match(/^([A-Za-z0-9_]+)\.([A-Za-z0-9_]+)\(/);
+    if (!match) return null;
+
+    const [, namespace, method] = match;
+    const symbol = `${namespace}.${method}`;
+    return { namespace, method, symbol };
+}
+
+function splitMethodTokens(tokens) {
+    const methods = [];
+    let currentMethod = null;
+
+    for (const token of tokens) {
+        if (token.type === 'heading' && token.depth === 2) {
+            if (currentMethod) methods.push(currentMethod);
+            currentMethod = {
+                heading: token.text.trim(),
+                tokens: [],
+            };
+            continue;
+        }
+        if (currentMethod) currentMethod.tokens.push(token);
+    }
+
+    if (currentMethod) methods.push(currentMethod);
+    return methods;
+}
+
+function splitSubsections(tokens) {
+    const sections = new Map();
+
+    let currentSection = 'description';
+    sections.set(currentSection, []);
+    for (const token of tokens) {
+        if (token.type === 'heading' && token.depth === 3) {
+            currentSection = token.text.trim().toLowerCase();
+            if (!sections.has(currentSection))
+                sections.set(currentSection, []);
+            continue;
+        }
+        sections.get(currentSection).push(token);
+    }
+
+    return sections;
+}
+
+function tokensToMarkdown(tokens) {
+    return tokens.map(token => token.raw).join('').trim();
+}
+
+function getInlineText(tokens = []) {
+    return tokens
+        .map(token => {
+            return token.tokens
+                ? getInlineText(token.tokens)
+                : token.text || token.raw || '';
+        })
+        .join('').trim();
+}
+
+function parseListItem(item) {
+    const firstToken = item.tokens?.[0];
+    if (!firstToken) return null;
+
+    const inlineTokens = firstToken.tokens ?? [];
+    const nameToken = inlineTokens.find(token => token.type === 'codespan');
+
+    if (!nameToken) {
+        return {
+            name: null,
+            description: getInlineText(inlineTokens),
+            markdown: tokensToMarkdown(item.tokens ?? []),
+        };
+    }
+
+    const name = nameToken.text;
+    const nameIndex = inlineTokens.indexOf(nameToken);
+    const description = getInlineText(inlineTokens.slice(nameIndex + 1))
+        .replace(/^:\s*/, '')
+        .trim();
+
+    return {
+        name,
+        description,
+        markdown: tokensToMarkdown(item.tokens ?? []),
+    };
+}
+
+function parseListSection(tokens) {
+    const list = tokens.find(token => token.type === 'list');
+    return list
+        ? list.items.map(parseListItem).filter(Boolean)
+        : [];
+}
+
+function findSection(sections, name) {
+    return sections.get(name.toLowerCase()) ?? [];
+}
+
+function findReturnSection(sections) {
+    for (const [heading, tokens] of sections) {
+        const match = heading.match(/^return\s+(.+?)(?:\s+\(awaited\))?:?$/);
+        if (!match) continue;
+
+        return {
+            type: match?.[1] ?? null,
+            awaited: heading.includes('(awaited)'),
+            description: tokensToMarkdown(tokens),
+        };
+    }
+
+    return null;
+}
+
+function parseMethod(methodSection, sourceFile) {
+    const method = parseMethodHeading(methodSection.heading);
+    if (!method) return null;
+
+    const sections = splitSubsections(methodSection.tokens);
+    return {
+        ...method,
+        description: tokensToMarkdown(findSection(sections, 'description')),
+        parameters: parseListSection(findSection(sections, 'parameters')),
+        options: parseListSection(findSection(sections, 'options')),
+        returns: findReturnSection(sections),
+        sourceFile,
+    };
+}
+
+function parseApiDocument(markdown, sourceFile) {
+    const tokens = marked.lexer(markdown);
+    return splitMethodTokens(tokens)
+        .map(method => parseMethod(method, sourceFile))
+        .filter(Boolean);
+}
+
+async function loadApiDocument(filePath) {
+    const markdown = fs.readFileSync(filePath, 'utf8');
+    return parseApiDocument(markdown, path.basename(filePath));
+}
+
+function buildDocumentationIndex(methods) {
+    return Object.fromEntries(methods.map(method => [method.symbol, method]));
+}
+
+export async function loadDocs() {
+    await assertDocsRepositoryExists();
+    const files = await getMarkdownFiles(apiDocsPath);
+    const documents = await Promise.all(files.map(loadApiDocument));
+    const methods = documents.flat();
+    return {
+        repositoryPath: DOCS_REPO_PATH,
+        apiDocsPath,
+        methods,
+        bySymbol: buildDocumentationIndex(methods),
+    };
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
                 "dts-bundle-generator": "^9.5.1",
                 "eslint": "^9.34.0",
                 "eslint-config-prettier": "^10.1.8",
+                "marked": "^18.0.9",
                 "prettier": "^3.6.2",
                 "rollup": "^4.48.1",
                 "rollup-plugin-cleanup": "^3.2.1",
@@ -863,6 +864,7 @@
             "integrity": "sha512-klQbnPAAiGYFyI02+znpBRLyjL4/BrBd0nyWkdC0s/6xFLkXYQ8OoRrSkqacS1ddVxf/LDyODIKbQ5TgKAf/Fg==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@typescript-eslint/scope-manager": "8.56.1",
                 "@typescript-eslint/types": "8.56.1",
@@ -1067,6 +1069,7 @@
             "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "bin": {
                 "acorn": "bin/acorn"
             },
@@ -1333,6 +1336,7 @@
             "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.8.0",
                 "@eslint-community/regexpp": "^4.12.1",
@@ -1962,6 +1966,19 @@
                 "sourcemap-codec": "^1.4.8"
             }
         },
+        "node_modules/marked": {
+            "version": "18.0.9",
+            "resolved": "https://registry.npmjs.org/marked/-/marked-18.0.9.tgz",
+            "integrity": "sha512-/Sa4qiiHZxf0/FQdBBowr9q4r10krCwMvpK48FUBdXdUXScDxiQGR9zCPrFgRVR5LU3iySOiIjy09ZQvADir1w==",
+            "dev": true,
+            "license": "MIT",
+            "bin": {
+                "marked": "bin/marked.js"
+            },
+            "engines": {
+                "node": ">= 20"
+            }
+        },
         "node_modules/minimatch": {
             "version": "10.2.4",
             "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
@@ -2196,6 +2213,7 @@
             "integrity": "sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@types/estree": "1.0.8"
             },
@@ -2518,7 +2536,8 @@
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
             "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
             "dev": true,
-            "license": "0BSD"
+            "license": "0BSD",
+            "peer": true
         },
         "node_modules/type-check": {
             "version": "0.4.0",
@@ -2539,6 +2558,7 @@
             "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
             "dev": true,
             "license": "Apache-2.0",
+            "peer": true,
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
         "test": "echo \"Error: no test specified\" && exit 1",
         "build": "node build.mjs",
         "watch": "rollup -c -w",
-        "lint": "eslint --ignore-path .eslintignore --ext .js,.ts",
+        "lint": "eslint --ignore-pattern .eslintignore --ext .js,.ts",
         "format": "prettier --ignore-path .gitignore --write \"**/*.+(js|ts|json)\""
     },
     "repository": {
@@ -33,6 +33,7 @@
         "dts-bundle-generator": "^9.5.1",
         "eslint": "^9.34.0",
         "eslint-config-prettier": "^10.1.8",
+        "marked": "^18.0.9",
         "prettier": "^3.6.2",
         "rollup": "^4.48.1",
         "rollup-plugin-cleanup": "^3.2.1",

--- a/patchWithDocs.js
+++ b/patchWithDocs.js
@@ -1,0 +1,151 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import ts from 'typescript';
+
+import { loadDocs } from './loadDocs.js';
+
+const declarationsPath = './dist/declarations/api';
+
+function getSummary(markdown) {
+    if (!markdown) return '';
+    return markdown.split(/\n\s*\n/)[0]
+        .replace(/\s+/g, ' ')
+        .trim();
+}
+
+function getParameterDescription(parameter) {
+    return parameter.description
+        .replace(/^[A-Za-z][A-Za-z0-9[\]]*(?:\s+\(optional\))?\s*:\s*/, '')
+        .replace(/\s+/g, ' ')
+        .trim();
+}
+
+function addOptions(parameterDocs, documentation) {
+    parameterDocs.push({
+        name: 'options',
+        description: 'Options.',
+    });
+
+    for (const option of documentation.options) {
+        parameterDocs.push({
+            name: `options.${option.name}`,
+            description: getParameterDescription(option),
+        });
+    }
+}
+
+function getParameterDocs(declaration, documentation) {
+    const parameterDocs = [];
+
+    for (let index = 0; index < documentation.parameters.length; index++) {
+        const declarationParameter = declaration.parameters[index];
+        const documentationParameter = documentation.parameters[index];
+        if (!declarationParameter || !documentationParameter) continue;
+        parameterDocs.push({
+            name: declarationParameter.name.getText(),
+            description: getParameterDescription(documentationParameter),
+        });
+    }
+
+    if (documentation.options.length) {
+        const optionsParameter = declaration.parameters.find(
+            parameter => parameter.name.getText() === 'options',
+        );
+        if (optionsParameter) addOptions(parameterDocs, documentation);
+    }
+
+    return parameterDocs;
+}
+
+function jsDocSection(include, getLines) {
+    return include
+        ? [' *', ...getLines()]
+        : [];
+}
+
+function createJsDoc(declaration, documentation) {
+    const params = getParameterDocs(declaration, documentation);
+    return [
+        '/**',
+        ` * ${getSummary(documentation.description)}`,
+        ...jsDocSection(params.length, () => params.map(
+            param => ` * @param ${param.name} - ${param.description}`,
+        )),
+        ' */'
+    ].join('\n') + '\n';
+}
+
+function isExportedFunction(node) {
+    if (!ts.isFunctionDeclaration(node) || !node.name) return false;
+    return (
+        node.modifiers?.some(
+            modifier => modifier.kind === ts.SyntaxKind.ExportKeyword,
+        ) ?? false
+    );
+}
+
+function getPatches(sourceFile, namespace, docs) {
+    const patches = [];
+    for (const declaration of sourceFile.statements) {
+        if (!isExportedFunction(declaration)) continue;
+        const functionName = declaration.name.text;
+        const symbol = `${namespace}.${functionName}`;
+        const documentation = docs.bySymbol[symbol];
+        if (!documentation) {
+            console.warn(`No documentation found for ${symbol}`);
+            continue;
+        }
+
+        patches.push({
+            position: declaration.getStart(sourceFile),
+            text: createJsDoc(declaration, documentation),
+        });
+    }
+
+    return patches;
+}
+
+function patchSource(source, namespace, docs) {
+    const sourceFile = ts.createSourceFile(
+        `${namespace}.d.ts`,
+        source,
+        ts.ScriptTarget.Latest,
+        true,
+        ts.ScriptKind.TS,
+    );
+
+    const patches = getPatches(sourceFile, namespace, docs)
+        .sort((a, b) => b.position - a.position);
+    for (const patch of patches) {
+        source = source.slice(0, patch.position)
+            + patch.text
+            + source.slice(patch.position);
+    }
+
+    return source;
+}
+
+async function patchDeclarationFile(filePath, docs) {
+    const namespace = path.basename(filePath, '.d.ts');
+    const source = await fs.readFile(filePath, 'utf8');
+    const patchedSource = patchSource(source, namespace, docs);
+    await fs.writeFile(filePath, patchedSource);
+}
+
+async function getDeclarationFiles() {
+    const entries = await fs.readdir(declarationsPath, {
+        withFileTypes: true,
+    });
+
+    return entries
+        .filter(entry => entry.isFile())
+        .filter(entry => entry.name.endsWith('.d.ts'))
+        .map(entry => path.join(declarationsPath, entry.name));
+}
+
+export async function patchWithDocs() {
+    const docs = await loadDocs();
+    const files = await getDeclarationFiles();
+    for (const file of files)
+        await patchDeclarationFile(file, docs);
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,52 +1,49 @@
+// @ts-expect-error this does not interfere with bundling
 import type { Architecture, Mode, OperatingSystem } from './types/enums';
 
 declare global {
-    interface Window {
-        // --- globals ---
-        /** Mode of the application: window, browser, cloud, or chrome */
-        NL_MODE: Mode;
-        /** Application port */
-        NL_PORT: number;
-        /** Command-line arguments */
-        NL_ARGS: string[];
-        /** Basic authentication token */
-        NL_TOKEN: string;
-        /** Neutralinojs client version */
-        NL_CVERSION: string;
-        /** Application identifier */
-        NL_APPID: string;
-        /** Application version */
-        NL_APPVERSION: string;
-        /** Application path */
-        NL_PATH: string;
-        /** Application data path */
-        NL_DATAPATH: string;
-        /** Returns true if extensions are enabled */
-        NL_EXTENABLED: boolean;
-        /** Returns true if the client library is injected */
-        NL_GINJECTED: boolean;
-        /** Returns true if globals are injected */
-        NL_CINJECTED: boolean;
-        /** Operating system name: Linux, Windows, Darwin, FreeBSD, or Uknown */
-        NL_OS: OperatingSystem;
-        /** CPU architecture: x64, arm, itanium, ia32, or unknown */
-        NL_ARCH: Architecture;
-        /** Neutralinojs server version */
-        NL_VERSION: string;
-        /** Current working directory */
-        NL_CWD: string;
-        /** Identifier of the current process */
-        NL_PID: string;
-        /** Source of application resources: bundle or directory */
-        NL_RESMODE: string;
-        /** Release commit of the client library */
-        NL_CCOMMIT: string;
-        /** An array of custom methods */
-        NL_CMETHODS: string[];
-        // --- globals ---
-    }
-    /** Neutralino global object for custom methods **/
-    const Neutralino: any;
+    // --- globals ---
+    /** Mode of the application: window, browser, cloud, or chrome */
+    const NL_MODE: Mode;
+    /** Application port */
+    const NL_PORT: number;
+    /** Command-line arguments */
+    const NL_ARGS: string[];
+    /** Basic authentication token */
+    const NL_TOKEN: string;
+    /** Neutralinojs client version */
+    const NL_CVERSION: string;
+    /** Application identifier */
+    const NL_APPID: string;
+    /** Application version */
+    const NL_APPVERSION: string;
+    /** Application path */
+    const NL_PATH: string;
+    /** Application data path */
+    const NL_DATAPATH: string;
+    /** Returns true if extensions are enabled */
+    const NL_EXTENABLED: boolean;
+    /** Returns true if the client library is injected */
+    const NL_GINJECTED: boolean;
+    /** Returns true if globals are injected */
+    const NL_CINJECTED: boolean;
+    /** Operating system name: Linux, Windows, Darwin, FreeBSD, or Uknown */
+    const NL_OS: OperatingSystem;
+    /** CPU architecture: x64, arm, itanium, ia32, or unknown */
+    const NL_ARCH: Architecture;
+    /** Neutralinojs server version */
+    const NL_VERSION: string;
+    /** Current working directory */
+    const NL_CWD: string;
+    /** Identifier of the current process */
+    const NL_PID: string;
+    /** Source of application resources: bundle or directory */
+    const NL_RESMODE: string;
+    /** Release commit of the client library */
+    const NL_CCOMMIT: string;
+    /** An array of custom methods */
+    const NL_CMETHODS: string[];
+    // --- globals ---
 }
 
 export * as filesystem from './api/filesystem';


### PR DESCRIPTION
This is an implementation to address #280.

This implementation pulls documentation from a local neutralinojs.github.io repository and parses its markdown files to augment the generated typescript declaration files with JSDoc comments prior to bundling.  This implementation adds one new dependency, which is `marked` for markdown parsing.

This implementation is dependent on an upstream change to dts-bundle-generator:
https://github.com/timocov/dts-bundle-generator/pull/365

This PR is here as a proof of concept and for discussion.
The output of running `npm run build` with these changes is available on this gist: https://gist.github.com/matortheeternal/5d53d03fad16f21e2d95a7410ff60aa5

Thanks!