### PR TITLE
solving failing testcases on neutralino ci/cd

### DIFF
--- a/src/api/computer.ts
+++ b/src/api/computer.ts
@@ -6,8 +6,11 @@ import type {
     CPUInfo,
     Display,
     Disk,
+    DiskInfo,
+    GPUInfo,
     MousePosition,
-    NetworkInterfaceInfo
+    NetworkInterfaceInfo,
+    NetworkInterfacesOptions
 } from '../types/api/computer';
 import type { SendKeyState } from '../types/enums';
 
@@ -39,6 +42,14 @@ export function getDisks(): Promise<Disk> {
     return sendMessage('computer.getDisks');
 };
 
+export function getDiskInfo(): Promise<DiskInfo> {
+    return sendMessage('computer.getDiskInfo');
+};
+
+export function getGPUInfo(): Promise<GPUInfo[]> {
+    return sendMessage('computer.getGPUInfo');
+};
+
 
 export function getHostname(): Promise<string> {
     return sendMessage('computer.getHostname');
@@ -60,8 +71,8 @@ export function sendKey(key: number, state: SendKeyState): Promise<void> {
     return sendMessage('computer.sendKey', { key, state });
 }
 
-export function getNetworkInterfaces(): Promise<NetworkInterfaceInfo> {
-    return sendMessage('computer.getNetworkInterfaces');
+export function getNetworkInterfaces(options?: NetworkInterfacesOptions): Promise<NetworkInterfaceInfo[]> {
+    return sendMessage('computer.getNetworkInterfaces', options);
 };
 
 export function getMachineId(): Promise<string> {

--- a/src/api/filesystem.ts
+++ b/src/api/filesystem.ts
@@ -95,6 +95,10 @@ export function move(source: string, destination: string): Promise<void> {
     return sendMessage('filesystem.move', { source, destination });
 };
 
+export function moveToTrash(path: string): Promise<void> {
+    return sendMessage('filesystem.moveToTrash', { path });
+};
+
 export function getStats(path: string): Promise<Stats> {
     return sendMessage('filesystem.getStats', { path });
 };

--- a/src/api/os.ts
+++ b/src/api/os.ts
@@ -82,3 +82,7 @@ export function trashItem(path: string): Promise<string> {
 export function getLocaleInfo(): Promise<LocaleInfo> {
     return sendMessage('os.getLocaleInfo');
 };
+
+export function getLocale(): Promise<LocaleInfo> {
+    return sendMessage('os.getLocale');
+};

--- a/src/api/window.ts
+++ b/src/api/window.ts
@@ -77,6 +77,10 @@ export function setIcon(icon: string): Promise<void> {
     return sendMessage('window.setIcon', { icon });
 }
 
+export function setBadge(count: number): Promise<void> {
+    return sendMessage('window.setBadge', { count });
+}
+
 export function move(x: number, y: number): Promise<void> {
     return sendMessage('window.move', { x, y });
 }

--- a/src/types/api/computer.ts
+++ b/src/types/api/computer.ts
@@ -49,6 +49,30 @@ export interface Disk {
     free: number;
 }
 
+export interface DiskInfo {
+    id: number;
+    name: string;
+    vendor: string;
+    model: string;
+    serial: string;
+    mountPoint: string;
+    fileSystem: string;
+    interface: string;
+    total: number;
+    used: number;
+    free: number;
+    usedPercent: number;
+}
+
+export interface GPUInfo {
+    id: number;
+    vendor: string;
+    name: string;
+    memorySize: number;
+    cacheSize: number;
+    maxFrequency: number;
+}
+
 export interface Resolution {
     width: number;
     height: number;
@@ -67,5 +91,15 @@ export interface NetworkInterfaceAddress {
 }
 
 export interface NetworkInterfaceInfo {
-    [key: string]: NetworkInterfaceAddress;
+    name: string;
+    ipv4: string[];
+    ipv6: string[];
+    mac: string;
+    isUp: boolean;
+    isLoopback: boolean;
+    isInternal: boolean;
+}
+
+export interface NetworkInterfacesOptions {
+    excludeLoopback?: boolean;
 }


### PR DESCRIPTION
Adds client-side wrappers for native methods that had no JS binding yet, so `Neutralino.*` calls don't come back `undefined` .
Adding in reference to https://github.com/neutralinojs/neutralinojs/pull/1825